### PR TITLE
Got it compiling with Java 9.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
@@ -63,8 +63,8 @@
                   <shadedPattern>org.kohsuke.file_leak_detector.args4j</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.kohsuke.asm3</pattern>
-                  <shadedPattern>org.kohsuke.file_leak_detector.asm3</shadedPattern>
+                  <pattern>org.kohsuke.asm5</pattern>
+                  <shadedPattern>org.kohsuke.file_leak_detector.asm5</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -88,13 +88,6 @@
       <version>2.0.16</version>
     </dependency>
     <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>6.0</version>
-      <scope>system</scope>
-      <systemPath>${toolsjar}</systemPath>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.0.1</version>
@@ -107,34 +100,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-
-  <profiles>
-    <profile>
-        <id>default-profile</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-            <file>
-                <exists>${java.home}/../lib/tools.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-        </properties>
-    </profile>
-    <profile>
-        <id>mac-profile</id>
-        <activation>
-            <activeByDefault>false</activeByDefault>
-            <file>
-                <exists>${java.home}/../Classes/classes.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
-        </properties>
-    </profile>
-  </profiles>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
                   <shadedPattern>org.kohsuke.file_leak_detector.args4j</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.kohsuke.asm5</pattern>
-                  <shadedPattern>org.kohsuke.file_leak_detector.asm5</shadedPattern>
+                  <pattern>org.kohsuke.asm6</pattern>
+                  <shadedPattern>org.kohsuke.file_leak_detector.asm6</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -79,8 +79,8 @@
   <dependencies>
     <dependency>
       <groupId>org.kohsuke</groupId>
-      <artifactId>asm5</artifactId>
-      <version>5.0.1</version>
+      <artifactId>asm6</artifactId>
+      <version>6.0_BETA</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -1,9 +1,9 @@
 package org.kohsuke.file_leak_detector;
 
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
-import org.kohsuke.asm5.commons.LocalVariablesSorter;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
+import org.kohsuke.asm6.commons.LocalVariablesSorter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.CodeGenerator;
 import org.kohsuke.file_leak_detector.transform.MethodAppender;
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.zip.ZipFile;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Java agent that instruments JDK classes to keep track of where file descriptors are opened.

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -1,6 +1,5 @@
 package org.kohsuke.file_leak_detector;
 
-import com.sun.tools.attach.VirtualMachine;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -25,10 +24,10 @@ import java.util.logging.Logger;
 public class Main {
     @Argument(index=0,metaVar="PID",usage="Process ID to activate file leak detector",required=true)
     public String pid;
-    
+
     @Argument(index=1,metaVar="OPTSTR",usage="Packed option string of the form key1[=value1],key2[=value2],...")
     public String options;
-    
+
     public static void main(String[] args) throws Exception {
         Main main = new Main();
         CmdLineParser p = new CmdLineParser(main);
@@ -84,7 +83,7 @@ public class Main {
      */
     protected ClassLoader wrapIntoClassLoader(File toolsJar) throws MalformedURLException {
         URL jar = toolsJar.toURI().toURL();
-        
+
         ClassLoader base = getClass().getClassLoader();
         if (base instanceof URLClassLoader) {
             try {

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
@@ -1,10 +1,10 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.kohsuke.asm6.Label;
+import org.kohsuke.asm6.MethodVisitor;
+import org.kohsuke.asm6.Type;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * Convenience method to generate bytecode.
@@ -13,7 +13,7 @@ import static org.kohsuke.asm5.Opcodes.*;
  */
 public class CodeGenerator extends MethodVisitor {
     public CodeGenerator(MethodVisitor mv) {
-        super(ASM5,mv);
+        super(ASM6,mv);
     }
 
     public void println(String msg) {

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
@@ -1,8 +1,8 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm5.MethodVisitor;
+import org.kohsuke.asm6.MethodVisitor;
 
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * {@link MethodTransformSpec} that adds some code right before the return statement.
@@ -22,7 +22,7 @@ public abstract class MethodAppender extends MethodTransformSpec {
     @Override
     public MethodVisitor newAdapter(MethodVisitor base, int access, String name, String desc, String signature, String[] exceptions) {
         final CodeGenerator cg = new CodeGenerator(base);
-        return new MethodVisitor(ASM5,base) {
+        return new MethodVisitor(ASM6,base) {
             @Override
             public void visitInsn(int opcode) {
                 if(opcode==RETURN)

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/MethodTransformSpec.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/MethodTransformSpec.java
@@ -1,6 +1,6 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm5.MethodVisitor;
+import org.kohsuke.asm6.MethodVisitor;
 
 /**
  * Transforms a specific method.

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
@@ -1,9 +1,9 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.ClassVisitor;
-import org.kohsuke.asm5.ClassWriter;
-import org.kohsuke.asm5.MethodVisitor;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.ClassVisitor;
+import org.kohsuke.asm6.ClassWriter;
+import org.kohsuke.asm6.MethodVisitor;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
@@ -12,8 +12,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.kohsuke.asm5.ClassReader.*;
-import static org.kohsuke.asm5.Opcodes.*;
+import static org.kohsuke.asm6.ClassReader.*;
+import static org.kohsuke.asm6.Opcodes.*;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -38,7 +38,7 @@ public class TransformerImpl implements ClassFileTransformer {
 
         ClassReader cr = new ClassReader(classfileBuffer);
         ClassWriter cw = new ClassWriter(/*ClassWriter.COMPUTE_FRAMES|*/ClassWriter.COMPUTE_MAXS);
-        cr.accept(new ClassVisitor(ASM5,cw) {
+        cr.accept(new ClassVisitor(ASM6,cw) {
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);

--- a/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.util.CheckClassAdapter;
+import org.kohsuke.asm6.ClassReader;
+import org.kohsuke.asm6.util.CheckClassAdapter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.TransformerImpl;
 

--- a/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.kohsuke.asm3.ClassReader;
-import org.kohsuke.asm3.util.CheckClassAdapter;
+import org.kohsuke.asm5.ClassReader;
+import org.kohsuke.asm5.util.CheckClassAdapter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.TransformerImpl;
 


### PR DESCRIPTION
Java 9 no longer supports 1.5

removed references to tools.jar as it's removed from Java 9.

Remove an unnecessary import (which is probably why tools.jar is needed)

fixed an error related to asm3 vs asm5 in the package.