### PR TITLE
Avoid using System.exit because it kills the JVM

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -58,7 +58,8 @@ public class AgentMain {
         if(agentArguments!=null) {
             for (String t : agentArguments.split(",")) {
                 if(t.equals("help")) {
-                    usageAndQuit();
+                    usage();
+                    return;
                 } else
                 if(t.startsWith("threshold=")) {
                     Listener.THRESHOLD = Integer.parseInt(t.substring(t.indexOf('=')+1));
@@ -109,7 +110,8 @@ public class AgentMain {
                     }
                 } else {
                     System.err.println("Unknown option: "+t);
-                    usageAndQuit();
+                    usage();
+                    return;
                 }
             }
         }
@@ -181,10 +183,9 @@ public class AgentMain {
         });
     }
 
-    private static void usageAndQuit() {
+    private static void usage() {
         System.err.println("File leak detector arguments (to specify multiple values, separate them by ',':");
         printOptions();
-        System.exit(-1);
     }
 
     static void printOptions() {

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -40,7 +40,6 @@ public class Main {
             p.printUsage(System.err);
             System.err.println("\nOptions:");
             AgentMain.printOptions();
-            System.exit(1);
         }
     }
 


### PR DESCRIPTION
Avoid using the **System.exit** instruction because it kills the JVM in the server. Specifically it kills the _Jenkins_ instance running in the same machine. For example, when this process is called with wrong arguments.

@reviewbybees @kohsuke 