### PR TITLE
Add an option to the command line to keep compatibility

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -48,6 +48,8 @@ import org.kohsuke.file_leak_detector.transform.TransformerImpl;
  */
 @SuppressWarnings("Since15")
 public class AgentMain {
+    private static boolean noexit;
+
     public static void agentmain(String agentArguments, Instrumentation instrumentation) throws Exception {
         premain(agentArguments,instrumentation);
     }
@@ -56,7 +58,14 @@ public class AgentMain {
         int serverPort = -1;
         
         if(agentArguments!=null) {
-            for (String t : agentArguments.split(",")) {
+            String[] arguments = agentArguments.split(",");
+
+            // Check it first to establish the flag before any error in the arguments process
+            if(Arrays.asList(arguments).contains("-noexit")) {
+                noexit = true;
+            }
+
+            for (String t : arguments) {
                 if(t.equals("help")) {
                     usageAndQuit();
                 } else
@@ -184,11 +193,13 @@ public class AgentMain {
     private static void usageAndQuit() {
         System.err.println("File leak detector arguments (to specify multiple values, separate them by ',':");
         printOptions();
-        System.exit(-1);
+        if (!noexit)
+            System.exit(-1);
     }
 
     static void printOptions() {
         System.err.println("  help          - show the help screen.");
+        System.err.println("  -noexit       - do not exit with error code terminating the JVM");
         System.err.println("  trace         - log every open/close operation to stderr.");
         System.err.println("  trace=FILE    - log every open/close operation to the given file.");
         System.err.println("  error=FILE    - if 'too many open files' error is detected, send the dump here.");

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -3,6 +3,7 @@ package org.kohsuke.file_leak_detector;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -28,6 +29,9 @@ public class Main {
     @Argument(index=1,metaVar="OPTSTR",usage="Packed option string of the form key1[=value1],key2[=value2],...")
     public String options;
 
+    @Option(name = "-noexit", usage = "Indicate whether the process is not going to exit with a return code to avoid terminating the currently running Java Virtual Machine")
+    public boolean noexit;
+
     public static void main(String[] args) throws Exception {
         Main main = new Main();
         CmdLineParser p = new CmdLineParser(main);
@@ -40,7 +44,8 @@ public class Main {
             p.printUsage(System.err);
             System.err.println("\nOptions:");
             AgentMain.printOptions();
-            System.exit(1);
+            if (!main.noexit)
+                System.exit(1);
         }
     }
 


### PR DESCRIPTION
This proposal allows to keep the compatibility with existing clients of this library. If the parameter `-noexit` is not set, all work as always. If you set the `-noexit` option in the command line (or agent args), the process doesn't exit with `System.exit()`.

@reviewbybees @kohsuke