### PR TITLE
[JENKINS-53394] A invalid property set on the configuration from the UI of file-leak-detector kills the Jenkins instance

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.zip.ZipFile;
 
+import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.asm6.Label;
 import org.kohsuke.asm6.MethodVisitor;
 import org.kohsuke.asm6.Type;
@@ -111,7 +112,7 @@ public class AgentMain {
                 } else {
                     System.err.println("Unknown option: "+t);
                     usage();
-                    return;
+                    throw new CmdLineException("Unknown option: "+t);
                 }
             }
         }

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -58,7 +58,8 @@ public class AgentMain {
         if(agentArguments!=null) {
             for (String t : agentArguments.split(",")) {
                 if(t.equals("help")) {
-                    usageAndQuit();
+                    usage();
+                    return;
                 } else
                 if(t.startsWith("threshold=")) {
                     Listener.THRESHOLD = Integer.parseInt(t.substring(t.indexOf('=')+1));
@@ -109,7 +110,8 @@ public class AgentMain {
                     }
                 } else {
                     System.err.println("Unknown option: "+t);
-                    usageAndQuit();
+                    usage();
+                    return;
                 }
             }
         }
@@ -181,10 +183,9 @@ public class AgentMain {
         });
     }
 
-    private static void usageAndQuit() {
+    private static void usage() {
         System.err.println("File leak detector arguments (to specify multiple values, separate them by ',':");
         printOptions();
-        System.exit(-1);
     }
 
     static void printOptions() {

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -1,7 +1,6 @@
 package org.kohsuke.file_leak_detector;
 
 import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
 import java.io.File;
@@ -34,7 +33,11 @@ public class Main {
         try {
             p.parseArgument(args);
             main.run();
-        } catch (CmdLineException e) {
+        } catch (Exception e) {
+            /* The main cause of the exception in the agent is lost outside of the loadAgent method.
+            The instrumentation framework remove it in the AgentInitializationException object. We only can print
+            an error to let the parent invoker know something went wrong
+             */
             System.err.println(e.getMessage());
             System.err.println("java -jar file-leak-detector.jar PID [OPTSTR]");
             p.printUsage(System.err);

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -40,7 +40,6 @@ public class Main {
             p.printUsage(System.err);
             System.err.println("\nOptions:");
             AgentMain.printOptions();
-            System.exit(1);
         }
     }
 


### PR DESCRIPTION
See [[JENKINS-53394] A invalid property set on the configuration from the UI of file-leak-detector kills the Jenkins instance](https://issues.jenkins-ci.org/browse/JENKINS-53394)

Remove the System.exit to avoid killing the Java Virtual Machine.

Discussed several approaches in:
* https://github.com/kohsuke/file-leak-detector/pull/39 Remove System.exit
* https://github.com/kohsuke/file-leak-detector/pull/40 Remove System.exit plus optional argument

This PR is the option chosen, removed System.exit and added an exception to be able to know what went on in the agent.